### PR TITLE
fix UUIDV4 import

### DIFF
--- a/src/ui/menu/Menu.ts
+++ b/src/ui/menu/Menu.ts
@@ -6,7 +6,7 @@ import { LiteEvent } from '../../utils/LiteEvent';
 import { Point } from '../../utils/Point';
 import { Size } from '../../utils/Size';
 import { MeasureString } from '../../utils/String';
-import { UUIDV4 } from '../../utils/uuidv4';
+import { UUIDV4 } from '../../utils/UUIDV4';
 import { Container } from '../Container';
 import { Screen } from '../Screen';
 import { Sprite } from '../Sprite';


### PR DESCRIPTION
It fixes UUIDV4 import on case-sensitive OS
```
src/ui/menu/Menu.ts:9:24 - error TS2307: Cannot find module '../../utils/uuidv4'.
9 import { UUIDV4 } from '../../utils/uuidv4';
```