### PR TITLE
add collisions parameter to attachTo(Bone)

### DIFF
--- a/src/models/Entity.ts
+++ b/src/models/Entity.ts
@@ -365,7 +365,7 @@ export class Entity {
     return new Vector3(o[0], o[1], o[2]);
   }
 
-  public attachTo(entity: Entity, position: Vector3, rotation: Vector3): void {
+  public attachTo(entity: Entity, position: Vector3, rotation: Vector3, collisions = false): void {
     AttachEntityToEntity(
       this.handle,
       entity.Handle,
@@ -378,14 +378,14 @@ export class Entity {
       rotation.z,
       false,
       false,
-      false,
+      collisions,
       false,
       2,
       true,
     );
   }
 
-  public attachToBone(entityBone: EntityBone, position: Vector3, rotation: Vector3): void {
+  public attachToBone(entityBone: EntityBone, position: Vector3, rotation: Vector3, collisions = false): void {
     AttachEntityToEntity(
       this.handle,
       entityBone.Owner.Handle,
@@ -398,7 +398,7 @@ export class Entity {
       rotation.z,
       false,
       false,
-      false,
+      collisions,
       false,
       2,
       true,


### PR DESCRIPTION
Had the need to attach and retain collisions.

Both of the added parameters default to `false` to provide backwards compatibility.