### PR TITLE
Fix a bug caused by tree shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fivem-js",
   "version": "1.5.1",
   "description": "Javascript/Typescript wrapper for the FiveM natives",
-  "sideEffects": false,
+  "sideEffects": ["./lib/models/*.js"],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
The tree shaking causes a bug that gives problems to all the files inside the models folder. It would be better to find a fix but until we understand the problem it is better to exclude thems

![image](https://user-images.githubusercontent.com/10401566/119497972-6e037900-bd65-11eb-84cc-2022846b9f7f.png)
as soon as the script is started